### PR TITLE
Wrapper for derivative objects

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,8 +10,8 @@ project = "pykoopman"  # package name
 copyright = f"2020, {author}"
 
 module = importlib.import_module(project)
-# version = release = getattr(module, "__version__")
-version = "0.0.1"
+version = release = getattr(module, "__version__")
+# version = "0.0.1"
 
 # The master toctree document.
 master_doc = "index"
@@ -24,6 +24,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.mathjax",
     "sphinx_nbexamples",
+    "sphinx.ext.intersphinx",
 ]
 
 apidoc_module_dir = f"../{project}"
@@ -66,6 +67,10 @@ example_gallery_config = dict(
     gallery_dirs=["examples"],
     pattern=".+.ipynb",
 )
+
+intersphinx_mapping = {
+    "derivative": ("https://derivative.readthedocs.io/en/latest/", None)
+}
 
 # -- Options for manual page output ---------------------------------------
 

--- a/examples/differentiation.ipynb
+++ b/examples/differentiation.ipynb
@@ -1,0 +1,219 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Differentiation methods\n",
+    "This notebook explores various choices of differentiation methods that can be used with PyKoopman's `KoopmanContinuous` class."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The optional parameter `differentiator` of the `KoopmanContinuous` class allows one to pass in custom time differentiation methods. `differentiator` should be callable with the call signature `differentiator(x, t)` where `x` is a 2D numpy `ndarray` with each example occupying a *row* and `t` is a 1D numpy `ndarray` containing the points in time for each row in `x`.\n",
+    "\n",
+    "Two common options for `differentiator` are\n",
+    "\n",
+    "* Methods from the [derivative](https://derivative.readthedocs.io/en/latest/) package, called via the `pykoopman.differentiation.Derivative` wrapper.\n",
+    "* Entirely custom methods."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-10-20T00:20:41.905651Z",
+     "start_time": "2020-10-20T00:20:41.034185Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from derivative import dxdt\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "import pykoopman as pk"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-10-20T00:20:42.078894Z",
+     "start_time": "2020-10-20T00:20:41.907294Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXwAAAEWCAYAAABliCz2AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy86wFpkAAAACXBIWXMAAAsTAAALEwEAmpwYAAAXP0lEQVR4nO3dfbRldX3f8feHAbE+BAaYRASGgUJUzEOVG6HUZbFgRBKdpKktPqwFBkLSSGLNI12smi7a1dLY1MRIaillBa0FWtMmE8UqFmhWYwe5k4UCGmScSGBK5GlEiVEZ+faPs8ecuXPOnXvueT77/Vrrrtln7332/t5993zP73z3b/92qgpJ0uI7ZNoBSJImw4QvSS1hwpekljDhS1JLmPAlqSVM+JLUEiZ8tVqSjyW5cEL7en+SfzaJfUm9xH74mmdJvgQ8Bzipqv6ymXcJ8NaqOnuKoUkzxxa+FsEG4B3TDkKadSZ8LYJ3A7+U5MheC5OcleTOJE82/57Vtez25hsBSU5J8r+b9R5LclMz/+okv7Fim9uSvLPHvpLkPUkeSfLVJHcn+b5m2e8m+ZfN9NlJHkryi826Dyd5W9d2Dk/yb5P8eZIvN+WgvzH8oVKbmfC1CJaB24FfWrkgyVHAR4H3AkcD/w74aJKje2znXwCfADYCxwO/3cy/HnhTkkOabR4DnAv8lx7b+GHgVcD3AkcA/xB4vE/cL2jWOQ64GLg6ycZm2VXNNv4WcEqzzrv6bEdaExO+FsW7gJ9LsmnF/B8B7q+qD1bV3qq6AfhT4PU9tvE0cCLwwqr6RlX9H4Cq+jTwJHBOs94FwO1V9eU+23g+8GI618g+X1UP94n5aeDKqnq6qm4GngJelCTApcA7q+qJqvoa8K+a/UrrZsLXQqiqe4CPAJevWPRC4IEV8x6g02Je6VeAAJ9Ocm+Sn+xadj3w1mb6rcAH+8RxK/A+4GrgkSTXJPmuPmE/XlV7u15/HXgesInOhegdSb6S5CvA/2zmS+tmwtci+TXgp9g/mf8/Oq32bpuB3SvfXFV/UVU/VVUvBH4a+J0kpzSL/zOwNckPAi8Bfr9fEFX13qo6HTiNTlnmlwf8PR4D/gp4aVUd2fwcUVXPG3A70n5M+FoYVbUTuAn4+a7ZNwPfm+TNSQ5N8o/oJOKPrHx/kjcmOb55uQco4Jlm2w8Bd9Jp2f9eVf1VrxiS/FCSM5IcBvwl8I192xjg93gG+I/Ae5J8d7Pd45K8dpDtSCuZ8LVorgSeu+9FVT0O/Cjwi3Qunv4K8KNV9ViP9/4QcEeSp4BtwDuqalfX8uuB76dPOafxXXSS9R46paPH6fQiGtSvAjuB7Um+CnwSeNE6tiN9hzdeSWuU5FV0Sjsnlv9xNIds4Utr0JRo3gFca7LXvDLhSweR5CXAV4Bjgd+cajDSECzpSFJL2MKXpJY4dNoB9HPMMcfUli1bph2GJM2VHTt2PFZVPW/Sm9mEv2XLFpaXl6cdhiTNlSQr7yz/Dks6ktQSJnxJagkTviS1hAlfklrChC9JLWHCl6SWMOG32I4H9nD1bTvZ8cCeaYciaQJmth++xmvHA3t4y7Xb+dbeZ3jWoYfwoUvO5PQTNx78jZLmli38ltq+63G+tfcZnil4eu8zbN/V7znbkhbFSBJ+kuuSPJLknj7Lk+S9SXYm+WySl49iv1q/M08+mmcdeggbAocdeghnnnz0tEOSNGajKun8Lp0HN3+gz/LXAac2P2cA/775V33seGAP23c9zpknHz2WUsvpJ27kQ5ecOdZ9SJotI0n4VfVHSbassspW4APNgyO2JzkyybFV9fAo9r9o1ltfH/RD4vQTN5ropRaZ1EXb44AHu14/1MzbL+EnuRS4FGDz5s0TCm329KqvHywxT+oibL8PlUHnS5q8meqlU1XXANcALC0ttfbJLPvq60/vfWbN9fX1fEgMqt+HyqDzJU3HpHrp7AZO6Hp9fDNPPeyrr//CD79ozUlytYuwo+pv369nz6DzJU3HpFr424DLktxI52Ltk9bvVzdofb3fRdhRtrL7ffMYdL6k6RhJwk9yA3A2cEySh4BfAw4DqKr3AzcD5wM7ga8DbxvFfrW/Xh8Soyz19PtQGXS+pOkYVS+dNx1keQFvH8W+NNiF0FG3svt98xh0vqTJm6mLtjq4QUs0trIl7WPCnzPrKdHYypYEjqUzdxZ9SARH8JTGxxb+nFnkEo399qXxMuHPoXGXaKZ1d+wkbh6T2syEr/1Ms5Vtv31pvEz42s80W9mLXK6SZoEJX/uZdivbHkXS+JjwR2zeR4e0lS0tLhP+CC1KLxNb2dJish/+CDk6pKRZZsIfoUW/KUrSfLOkM0LWvyXNMhP+iFn/ljSrLOlIUkuY8CWpJUz4ktQSJvwpa+twwG39vaVp8qLtFC3KjVqDauvvLU2bLfwpauuNWm39vaVpM+FPUVtv1Grr7y1NW6pq2jH0tLS0VMvLy9MOY+zmfbC19VrP793WYyUNIsmOqlrqtcwa/pS19UatQX9v6/7S8CzpTIi9UoZj3V8ani38CbB1OrxpP5hFWgQm/Anw4dzDc2A6aXgm/AmwdToabb3eIY2KCX8CbJ1KmgUm/AmxdSpp2uylI0ktYcKXpJYw4UtSS5jwV+HNUpIWiRdt+/BmKUmLxhZ+H97KPz/8JiatjS38PrxZaj74TUxaOxN+H94sNR9WG7bC4ZSl/Y0k4Sc5D/gtYANwbVVdtWL5RcC7gd3NrPdV1bWj2Pc4ebPU7Ov3TcyWv3SgoRN+kg3A1cBrgIeAO5Nsq6rPrVj1pqq6bNj9zQpbj7Oh3zcxB6yTDjSKFv4rgJ1VtQsgyY3AVmBlwl8Yth5nS69vYl6DkQ40ioR/HPBg1+uHgDN6rPcTSV4FfAF4Z1U9uHKFJJcClwJs3rx5BKGNh63H2ec1GOlAk+qW+YfAlqr6AeAW4PpeK1XVNVW1VFVLmzZtmlBog/Mh3PPh9BM38vZXn2KylxqjaOHvBk7oen08f31xFoCq6u7Efi3w6yPY79TYepQ0j0aR8O8ETk1yEp1EfwHw5u4VkhxbVQ83L98AfH4E+50qe/BImjdDJ/yq2pvkMuDjdLplXldV9ya5Eliuqm3Azyd5A7AXeAK4aNj9SpIGk6qadgw9LS0t1fLy8rTDkKS5kmRHVS31WuZYOpLUEiZ8SWoJE74ktYQJX5JawoSP46lLaofWD4/suDiS2qL1LXyfbCWpLVqf8B0XR90s72mRtb6k47g42sfynhZd6xM+OC6OOhz2Wouu9SUdaR/Le1p0tvClhuU9LToTvtTF8p4WmSUdSWoJE74ktYQJX61jX3u1lTV8tYp97dVmtvDVKg6loTYz4atV1tvX3jKQFoElHbXKevraWwbSojDhq3UG7WvvkAtaFJZ0pINwyAUtClv40kE45IIWhQlfWgOHXNAisKQjSS1hwpekljDhS1JLmPAlqSVM+JLUEiZ8SWqJViV8x0OR1Gat6YfveCiS2q41LXyHxZXUdq1J+I6HIqntWlPScTwUSW3XmoQPjociqd1GUtJJcl6S+5LsTHJ5j+WHJ7mpWX5Hki2j2K8kae2GTvhJNgBXA68DTgPelOS0FatdDOypqlOA9wD/Ztj9SpIGM4oW/iuAnVW1q6q+BdwIbF2xzlbg+mb6w8A5STKCfUvSQhnn/UKjqOEfBzzY9foh4Ix+61TV3iRPAkcDj41g/5K0EMZ9v9BMdctMcmmS5STLjz766LTDkaSJGvf9QqNI+LuBE7peH9/M67lOkkOBI4ADfpOquqaqlqpqadOmTesOyCEUJM2jcd8vNIqSzp3AqUlOopPYLwDevGKdbcCFwP8F/gFwa1XVCPZ9AIdQ0CTteGCP93ZoZMZ9v9DQCb+pyV8GfBzYAFxXVfcmuRJYrqptwH8CPphkJ/AEnQ+Fsej1lcj/iBoHGxcah3HeLzSSG6+q6mbg5hXz3tU1/Q3gjaPY18Hs+0r09N5nHEJBY2XjQvNm4e60dQgFTcpqjQtLPZpFGVMpfWhLS0u1vLw87TCkVfVK7JZ6NE1JdlTVUq9lC9fClyapV73VUo9m1Uz1w5cWgUNxay2m0X3cFr40Yl5H0sFMq+xnwpfGwKG4tZpplf0s6UjShE2r7GcLX5ImbFplPxO+JE3BNMp+lnQkqSVM+JLUEiZ8SWoJE74ktYQJX5JawoQvSS1hwpekljDhS1JLmPAlaYymMSpmP95pK0ljMmsPw7GFL0lj0mtUzGky4UvSmMzaw3As6UjSmMzaw3BM+JI0RrP0MBxLOtIEzVKPDbWPLXxpQmatx4baxxa+NCGz1mND7WPClyZk1npsaHDzXpKzpCNNyKz12NBgFqEkZ8KXJmiWemxoML1KcvP2t7SkI0lrsFpJbl5KPbbwJWkN+pXk5qnUY8KXpDXqVZKbp1KPJR1JGsI89b6yhS9JQ5in3lcmfGlG7Hhgz1wkDR1oXnpfmfClGTBPF/40v6zhSzPAYRc0CUMl/CRHJbklyf3Nvz2bJEm+neSu5mfbMPuUFtEi9PHW7EtVrf/Nya8DT1TVVUkuBzZW1a/2WO+pqnreINteWlqq5eXldccmzZteNXxLPRpUkh1VtdRr2bA1/K3A2c309cDtwAEJX9LBzXsfb82+YWv431NVDzfTfwF8T5/1np1kOcn2JD/Wb2NJLm3WW3700UeHDE2af/PUx1uz76AlnSSfBF7QY9EVwPVVdWTXunuq6oDmR5Ljqmp3kpOBW4FzquqLq+3Xko7UYXdNDWKokk5VnbvKhr+c5NiqejjJscAjfbaxu/l3V5LbgZcBqyZ8SR3z0sdbs2/Yks424MJm+kLgD1aukGRjksOb6WOAvwN8bsj9SpIGNGzCvwp4TZL7gXOb1yRZSnJts85LgOUknwFuA66qKhO+pKlrW5fXoXrpVNXjwDk95i8DlzTTnwK+f5j9SNKotbHLq3faSmqlNt7dbMKX1Ept7PLq4GmSWmmehjUeFRO+pNZqW5dXSzqS1BImfGlOta1LoYZnSUeaQ23sUqjh2cKX5lAbuxRqeCZ8aQ61sUvhJC1qucySjjSH2tilcFIWuVxmwpfmVNu6FE7KIj90xpKOJHVZ5HKZLXxJ6rLI5TITviStsKjlMks6ktQSJnxJagkTviS1hAlfklrChC9JLWHCl7TwFnWohEHZLVNqiR0P7FnIvuUHs8hDJQzKhC+1QJuT3iIPlTAoSzrSgulVvmjzcMqLPFTCoGzhSwukX0t+X9J7eu8zC5v0+pWsFnmohEGZ8KUF0q98sehJ72Alq0UdKmFQJnxpgazWkl/kpGedfm1M+NICWfSWfD9tKFmNQqpq2jH0tLS0VMvLy9MOQ9KcaGu305WS7KiqpV7LbOFLmiurXZxtc6JfCxO+pJnUK7G3+X6CUTDhS5o5/RK7F2eH441XkqZqkBvFvIlqOLbwJU3NoDeKtbUX0qiY8CVNzXpuFPPi7PqZ8CWNzKBdI9t6o9i0mPAljcR6etBYopksE76kgfVqya+3B40t+ckZqpdOkjcmuTfJM0l63tnVrHdekvuS7Exy+TD7lDRd+1ryv/GJ+3jLtdu/07vGHjSzb9gW/j3A3wf+Q78VkmwArgZeAzwE3JlkW1V9bsh9S5qCto7IuQiGSvhV9XmAJKut9gpgZ1Xtata9EdgKmPClOeSF1vk1iRr+ccCDXa8fAs7otWKSS4FLATZv3jz+yCQBg/WusSU/vw6a8JN8EnhBj0VXVNUfjDKYqroGuAY6o2WOctuSeltv7xoT/fw5aMKvqnOH3Mdu4ISu18c38yTNAMenaY9JjKVzJ3BqkpOSPAu4ANg2gf1KWgN717THUDX8JD8O/DawCfhokruq6rVJXghcW1XnV9XeJJcBHwc2ANdV1b1DRy5pJKzJt4dPvJKkBbLaE68cHlmSWsKEL6mvXmPVa345lo6knnyc4OKxhS+pp35PnVoPvynMBlv4knpabQiFQfhNYXaY8CX1NKrumt7YNTtM+JL6GsUQCqP6pqDhmfAljZU3ds0OE76ksXOwtdlgLx1JagkTviS1hAlfklrChC9JLWHCl6SWMOFLUkvM7Hj4SR4FHhhiE8cAj40onFEyrsEY12CMazCLGNeJVbWp14KZTfjDSrLc7yEA02RcgzGuwRjXYNoWlyUdSWoJE74ktcQiJ/xrph1AH8Y1GOMajHENplVxLWwNX5K0v0Vu4UuSupjwJakl5i7hJzkvyX1Jdia5vMfyw5Pc1Cy/I8mWrmX/tJl/X5LXTjiuX0jyuSSfTfK/kpzYtezbSe5qfrZNOK6Lkjzatf9LupZdmOT+5ufCCcf1nq6YvpDkK13Lxnm8rkvySJJ7+ixPkvc2cX82ycu7lo3zeB0srrc08dyd5FNJfrBr2Zea+XclWZ5wXGcnebLr7/WurmWrngNjjuuXu2K6pzmnjmqWjfN4nZDktiYX3JvkHT3WGd85VlVz8wNsAL4InAw8C/gMcNqKdX4WeH8zfQFwUzN9WrP+4cBJzXY2TDCuVwPPaab/8b64mtdPTfF4XQS8r8d7jwJ2Nf9ubKY3TiquFev/HHDduI9Xs+1XAS8H7umz/HzgY0CAM4E7xn281hjXWfv2B7xuX1zN6y8Bx0zpeJ0NfGTYc2DUca1Y9/XArRM6XscCL2+mnw98ocf/ybGdY/PWwn8FsLOqdlXVt4Abga0r1tkKXN9Mfxg4J0ma+TdW1Ter6s+Anc32JhJXVd1WVV9vXm4Hjh/RvoeKaxWvBW6pqieqag9wC3DelOJ6E3DDiPa9qqr6I+CJVVbZCnygOrYDRyY5lvEer4PGVVWfavYLkzu/1nK8+hnm3Bx1XJM8vx6uqj9ppr8GfB44bsVqYzvH5i3hHwc82PX6IQ48WN9Zp6r2Ak8CR6/xveOMq9vFdD7B93l2kuUk25P82IhiGiSun2i+On44yQkDvneccdGUvk4Cbu2aPa7jtRb9Yh/n8RrUyvOrgE8k2ZHk0inE87eTfCbJx5K8tJk3E8cryXPoJM3f65o9keOVTrn5ZcAdKxaN7RzzEYcTluStwBLwd7tmn1hVu5OcDNya5O6q+uKEQvpD4Iaq+maSn6bz7ejvTWjfa3EB8OGq+nbXvGker5mW5NV0Ev4ru2a/sjle3w3ckuRPmxbwJPwJnb/XU0nOB34fOHVC+16L1wN/XFXd3wbGfrySPI/Oh8w/qaqvjnLbq5m3Fv5u4ISu18c383quk+RQ4Ajg8TW+d5xxkeRc4ArgDVX1zX3zq2p38+8u4HY6n/oTiauqHu+K5Vrg9LW+d5xxdbmAFV+3x3i81qJf7OM8XmuS5Afo/A23VtXj++Z3Ha9HgP/B6EqZB1VVX62qp5rpm4HDkhzDDByvxmrn11iOV5LD6CT7D1XVf++xyvjOsXFcmBjXD51vJLvofMXfd6HnpSvWeTv7X7T9r830S9n/ou0uRnfRdi1xvYzORapTV8zfCBzeTB8D3M+ILl6tMa5ju6Z/HNhef32B6M+a+DY200dNKq5mvRfTuYCWSRyvrn1sof9FyB9h/wtqnx738VpjXJvpXJc6a8X85wLP75r+FHDeBON6wb6/H53E+efNsVvTOTCuuJrlR9Cp8z93User+d0/APzmKuuM7Rwb2cGd1A+dK9hfoJM8r2jmXUmn1QzwbOC/NSf/p4GTu957RfO++4DXTTiuTwJfBu5qfrY1888C7m5O+LuBiycc178G7m32fxvw4q73/mRzHHcCb5tkXM3rfw5cteJ94z5eNwAPA0/TqZFeDPwM8DPN8gBXN3HfDSxN6HgdLK5rgT1d59dyM//k5lh9pvk7XzHhuC7rOr+20/WB1OscmFRczToX0enI0f2+cR+vV9K5RvDZrr/V+ZM6xxxaQZJaYt5q+JKkdTLhS1JLmPAlqSVM+JLUEiZ8SWoJE740gCRHJvnZacchrYcJXxrMkXRGZJXmjglfGsxVwN9sxkp/97SDkQbhjVfSAJoRDj9SVd837VikQdnCl6SWMOFLUkuY8KXBfI3Oo+mkuWPClwZQnXHm/7h58LUXbTVXvGgrSS1hC1+SWsKEL0ktYcKXpJYw4UtSS5jwJaklTPiS1BImfElqif8PQFf4TRhw3S0AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "t = np.linspace(0, 2, 50)\n",
+    "x = np.sin(np.pi * t) + 0.1 * np.random.standard_normal(t.shape)\n",
+    "x_dot = np.pi * np.cos(np.pi *  t)\n",
+    "\n",
+    "plt.plot(t, x, '.')\n",
+    "plt.xlabel('t')\n",
+    "plt.title('Noisy sine');"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Derivative package\n",
+    "\n",
+    "All of the robust differentiation methods in the [derivative](https://derivative.readthedocs.io/en/latest/) package are available with the `pykoopman.differentiation.Derivative` wrapper class. One need only pass in the same keyword arguments to `Derivative` that one would pass to [derivative.dxdt](https://derivative.readthedocs.io/en/latest/api.html#dxdt-functional-interface).\n",
+    "\n",
+    "For example, we'll compute the derivative of a noisy sine function with `dxdt` and `Derivative` using spline-based numerical differentiation and compare the results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-10-20T00:20:42.281295Z",
+     "start_time": "2020-10-20T00:20:42.081151Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXIAAAEWCAYAAAB7QRxFAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy86wFpkAAAACXBIWXMAAAsTAAALEwEAmpwYAABH9UlEQVR4nO3deXxU5dn/8c81k0km+0ISCEsI+76HfRdURMC6oKjV0kVr1dZuj621tbbVX32qXazWtm7FPm64IgKCIovs+75JgAAJgYTsezIz9++PGULYA5nkZMj1fr3mxcw5Z85852S45p77nHMfMcaglFIqcNmsDqCUUqp+tJArpVSA00KulFIBTgu5UkoFOC3kSikV4LSQK6VUgNNCrvxGRJJFpERE7PVcT4qIGBEJ8le2hiQiLUXkKxEpFpE/W/D6y0Tke35a1ywRecof61KNJyD+oyj/EpF0oCXgrjV5ljHm4fqs1xhzBIiozzoC1P3ASSDKNPCJGSLyJNDZGPPNhnwdFVi0kDdfU40xi60OcZVoD+xu6CKu1IVo14o6g4jYReQ5ETkpIgdF5KHa3Rwiki4iE2st/6SIvOm7X9MlIiJ3iMjGs9b9ExGZ67t/o4hsEZEiETnqa2leKFO0iLwmIlkikikiT53qvhGRmSKy0pc5X0QOicgNtZ4bJyL/EZFjvvlzas2bIiJbRaRARFaLSN+LZBghIhtEpND37wjf9FnAt4BHfd1KE8/z3Fki8pKIfOZbZpWItBKRv/ky7RWRAbWWby0iH4pIju/9/Mg3fRLwK+AO33q21XqZ9r71FovI5yISX2t900Rkl+99LhORHrXmDRCRzb7nzQactebFi8g83/PyRGSFiGjNaIqMMXprZjcgHZh4gXkPAHuBdkAcsBQwQND5ngs8Cbzpu59yalkgDCgGutRadgMww3d/HNAHb2OiL3AC+MbZ6/E9/hj4NxAOJALrge/75s0EqoH7ADvwA+AYIL7584HZQCzgAMb6pg8AsoGhvud9y/feQs6zTeKAfOAe33u70/e4hW/+LOCpi2zvWXi7XgbhLZRLgEPAvb7XfgpY6lvWBmwCngCCgY7AQeD6s7d3rfUvAw4AXYFQ3+NnfPO6AqXAtb73/yiQ5lt3MHAY+Ilv3m2+bfmU77l/BP7lm+cARp/arnprWjf9dm2+5vhaWqdu9/mm3w78zRhz1BiTh/c/82UzxpQBn+AteohIF6A7MNc3f5kxZocxxmOM2Q68A4w9ez0i0hKYDPzYGFNqjMkG/grMqLXYYWPMK8YYN/AGkAS0FJEk4AbgAWNMvjGm2hiz3Pec+4F/G2PWGWPcxpg3gEpg2Hnezo3AfmPM/xljXMaYd/B+2U29jE3ysTFmkzGmAu8XU4Ux5r++zLPxfrEADAYSjDG/N8ZUGWMOAq+c9X7P5z/GmK+NMeXAe0B/3/Q7gPnGmC+MMdXAc3iL/Qjfe3Xg/XtXG2M+wPtle0o13m3Z3jd/hTFGu4+aIO0jb76+Yc7fR94aOFrr8eF6vMbbwJ+B3wN3AXN8BR4RGQo8A/TG2zIMAd4/zzra4y02WSJyaprtrIzHT90xxpT5lovA25LOM8bkX2C93xKRH9aaFoz3/Z+tNeduh8NAm/MseyEnat0vP8/jUzuJ2wOtRaSg1nw7sOIS6z9e635ZrfWdkd0Y4xGRo3izu4HMs4pz7ff5LN5fAJ/7tunLxphnLpFDWUBb5OpsWXi7VU5JPmt+Kd5uk1NaXWRdXwAJItIfb8v87Vrz3sbbOm9njInG+xNezlmDt2BXAvHGmBjfLcoY06sO7+UoECciMReY93StdcYYY8J8re2zHcNbYGtLBjLrkOFyHQUOnZUr0hgz2Tf/clvEZ2QXb0Vuhzd7FtBGan1DUuvvbYwpNsb8zBjTEZgG/FREJlzBe1INTAu5Ott7wI9EpK2IxAK/PGv+VmCGiDhEJBVvv+p5+X7Kv4+3ZReHt7CfEom3tVwhIkPwttjPt44s4HPgzyISJSI2EekkIud0w1zguZ8BL4lIrC/zGN/sV4AHRGSoeIX7dsBGnmdVC4CuInLXqR25QE9g3qUyXIH1QLGI/EJEQsW787m3iAz2zT8BpFzGTsf3gBtFZIKIOICf4f1iXA2sAVx4/94OEbkFGHLqib6dwZ19hb4Qbwve45d3qfxKC3nz9anvyIdTt499018BFgHbgM3AR2c97zdAJ7w7+37Hma3s83kbmAi8b4xx1Zr+IPB7ESnGu2PvvYus41683R67fa/7Ad6+27q4B29f7168Ozd/DGCM2Yh3B+mLvnWm4d1xeg5jTC4wBW8RzMW7w3CKMeZkHTPUma/PfArePu5DeHeSvgpE+xY51f2UKyKb67C+fcA3gRd865qK99DTKmNMFXAL3vedh7c/vfbfuwuwGCjBW/RfMsYsrcfbUw3k1J59pc5LRFLwFhTHWYVYKdVEaItcKaUCnBZypZQKcNq1opRSAU5b5EopFeAsOSEoPj7epKSkWPHSSikVsDZt2nTSGJNw9nRLCnlKSgobN2689IJKKaVqiMh5z7TWrhWllApwWsiVUirAaSFXSqkAp4VcKaUCnBZypZQKcFrIlVIqwAXMhSVKKl1szyggMTKE+IgQokMdnDmMslJKNU0ut4e80ipySiopq3IzOCXOr+sPmEKekV/GaysO1Tx22G3ERwaTEOEkPjKYlpFO+ifHEB8RYmFKpVRzZowhLbuEfSeKySmu5GRJJTnFleSVVnFqNBSnw05q+1i/NkQDppCfLK4643G120NWQQVZBRU1097dcIQeSVGM6ZpA/3YxOOzac6SUaniF5dWsOXCSr/af5ERhxUWXrah2U1LpItLp8NvrB0whjwlzMCgllpPFvp8nlecOjW0M7D5WxO5jRYSHBDGiUwtGdYmnbWzYedaolFJXzuMx7DpWxFf7c9h6tACP58IDEIpAdGgwCZEhxEcE477Islei3qMfiogT+ArvxXODgA+MMb+92HNSU1NNfU/RL6ty+Yp6BTnFVezJKmLXsULO93Z6t4nmnuHttdtFKeUXOzMLeWvdYbKLKs+Z53TYSU2JJaVFOPERISREhhAXHkxwUP17CERkkzEm9ZzpfijkAoQbY0p81wRcCTxijFl7oef4o5CfT25JJasO5LJyfw65JWd2xYQ4bNw8oC0Tuidis+lOUqXU5SupdPHu+iOsOZB7zrzOLSMY0yWBQe1jcTrsDfL6Fyrk9e5aMd5vghLfQ4fvZskg5y0iQpjWrzVT+yaxO6uIr74+yabDeRgDldUe3l1/hPWHcvnWiBTtblFK1ZkxhvWH8nhn/RGKK05364aFBDG6czyju8aTFB1qWT6/XFhCROzAJqAz8A9jzC/Os8z9wP0AycnJgw4fPu8gXn53IKeEN1ank5lfXjPNbhMm90nixr5JukNUKXVReaVV/N+aw2zPKDhj+pAOcdw5NJkoP+60vJQG61o560VigI+BHxpjdl5oufp0raSnL0fERquWfQlxRl/6CXiP4Vyw8zjzth07YydDm9hQfjShi/adK6XOa8uRfF5dcYiKanfNtNjwYO4Z1p5+7WLqvJ709OUcz91Lm8TetGs38orzNFjXSm3GmAIRWQpMAi5YyOtj7uZ/8HXJUQR4ILwLvVr0gug2EJMMSf3gPMU9yG5jWr/WpLaP5Y3V6aRle3uCMvPL+X/z9/DjiV1JbqFdLUqp05buzeatdYfPOIBifPdEbh3YltDgWn3gFYXsO/gFOzJXk5a/n5u73Eq3ATPPWNfavR+wMnsj1xdNqFchv5B6F3IRSQCqfUU8FLgW+N96J7uA4+UnAW8nfEJFCRzb7L0BiI0vo2KJaj2Ivj1uO6fF3jomlF/e0J0le7OZveEobo+hsLyaZxbu4cFxnendpm4tfKXU1csYw4ebM/lsR1bNtITIEL43ugOdEyO9E4qPw9eLIGsrFB1jmzuPr4y3gbj/+Ea6MfOMdTrswQC43Oce5eIP/miRJwFv+PrJbcB7xph5fljvOVzVFXSMbMexshMUVBUTf1b8So+L+blbqcrdQvDO//Cba/5KbJvBZywjIkzo0ZK2sWG8sGQ/5VVuKqs9PP/lfmaOSGFk5/iGiK6UCgAut4dZq9PPOColJT6cRyZ2Icrp4OChL/EcXErnE2nUPqajszhrCvmBggPek1pqnbmZnNCLwVXFtIvv1SC5/dpHXlf+OPzQVV1OUEk2FGZAUSYc38GG7C284fH+AVrZnDx++wIk+MJ7kjMLyvnrF1+TX3r6UMVvDGjDlL5JOo6LUs1MeZWbl5alsftYUc20vm1j+P7YjuTnbOWtVX8gvfwE7SSYR20tT9cIWxBFse1YHmynY9IgOiaPIzTMv2OpnNIofeSNKcgRCrHtvTeAvrfTOXc/U3e/y4Zja0iN6XZOEc/PO8CJnF107zYNgDYxofz6xh789YuvyfAd1TJnSyb5ZVXcPbQ9dj3eXKlmoaCs6ow6ADC2W0JNHYiIaEVmhbdb96ipIo1KuiQNg26TILEXUUHBTLUqPAHcIr8oY3BXV2A/q5C/+dkDrM3ZRrfIZG4d/BNatx0GeL+J/7E0jT1Zp7+Jx3RN4N7h7bVlrtRVrqTSxR8X7OF4rTFSzvfL/J2FD7M2ZwuD4/ty/YAHSGjVr9GzXnUt8osSOaeIHzu2kXU52wHYV3yE4uV/hI7XwaCZhAaH8+OJXc7oG/vq6xxiwhzc1L9No8dXSjWOSpebv3+5v6aIiwiT2m2jm+xD5JtnLDt52M+ZLDaio5OtiHpRzeZsmPCweIYl9EcQeoqTbuKEQ1/BZ49Czj6C7Da+O6oDwzu1qHnO3K3HWLYv28LUSqmG4vYYXl5+kAO+w5GDPLn0Cn2eZRmv8ub2V6goOPOkxeiYlCZZxKEZFfLomBTuvuElHr/2H9zaetzpGaUnYfGTVG6fjfG4mTkihV61DkN8c+1hthzJb/zASqkGY4zhrXWH2Xq0AID2lV/zc94gq+IgAHmeKhaufsbChJen2RTyU1olDaDlhN/CqJ+Cw3sSkPG4mbXt37wwZwYlRYd5cFwnUuLDvfMM/Hv5QdKyi62MrZTyo7nbjrF8Xw4AvcvW8z3Pe3RxephuiwVgSHwfrh1z0UFcm5RmV8hrJA+Fyc9CQjdWmBJ2mHL2l2by/+bPxFV0kEcmdiExynvqfrXbw/NfpnGsoPwSK1VKNXXL9mUzd+sxMIaRxQu51bOQpGjv//XUsDb8bNjj3Dv5ZcIjWlmctO6abyEHCI+HCb+lrN0QBO/e6SGRHYiI7USU08FPJnYl0undH1xW6eIvX3xNXmnVxdaolGrCthzJ5821hxFTTquKvzDEs5q2saHe//9xnZAbnqFD1ylWx7xszbuQA9jsTBr7JD8a8QS9wpK4acKfwObdLIlRTn48sSshDu/j/NIqXlqahsvtsTKxUuoKHCso5+WvDmJ3n8RZ+RSZQQf4IrYcN0CbVJjwBITGWh3zimgh9+nSeRI/uPVDHBGJZ0xPiQ/nwbEday5GcehkKe9vyrAiolLqClVUu/nnsgNUuTyEVW+l2J5PWLCdA1SypW0vGP0zcDitjnnFtJDXdp6Tf5as/hNfbXiQm/uePpJl8e4TbDqc15jJlFL18Na6IzX7uMrDrmNayo3YxcYtnW9m8Jgnan6FB6qr84QgP9mw5TU+SvsYgLL9j9Kv5S/YdsI7fOXrq9JpFxtGYlTgfosr1Rys3H+S1Wknax7fPSyZUZ2eYEjmtQ0ypKwVAvtrqIHlFB2puW+ryOe7lW+T7PSeAVZR5eYl3081pVTTdDSvjHdX78RuvJdnG9E5nlGd4xGb7aop4qCF/KImj/0dt3W9jdbi4AFbAuFlJ/hJ0PuE4f2JdjSvjNkbjlxiLUopK1RUu/nXkm1Q/jRJZc/RNhLuHpp8VY6fpIX8EsYN+xmPjnqKMJv3unxRVSf4uXMOQcZ7GOKyfTmsO3juFbWVUtYxxjBrxR6KT/6BQsnnkOMwKZ4/E2Kz5LrwDU4LeR0EdRgDwx+qeZzsyeA2eR/xFfM31qSTVagnCynVVCzfd4LY7a/SwlUAgNNhp2O7IYj96twtqIW8rlJGwqCZABwyVXxu20C8+0WM8VBZ7eHfyw/q8eVKNQHH8svIWvwi3Sr3MLU0giGEcXPHGxg77KdWR2swWsgvR7cbON5lAi+4synHQ2HQIVpUvQp4+8vn17rGn1Kq8bk9hhXz/48epRsACHcE8UD/mUwa/YTFyRqWFvLL1HLQ90hN8A4oH213MLbDsJp587ZncTSvzKpoSjV7K9esoGvmHMB7WkjLfhNxDPk2EuDHiV/K1f3uGoDYbMy49nlGx/flJyOfZPLE79ApMQIAj8fw2spD2sWilAXSMtJ4f8ev2O/wHiIc2bobMWMfPu+JflcbLeRXwB4UzB2T/03LjhOw2YRvj0whyO79sBzNK2PhruMWJ1SqeamuquTfix6hUCr4NLyYdZGG5GmPQ1Cw1dEahRZyP0iKDuUb/dsgphy7p4C5W4+Rka9dLEo1ls+2bqGo2nvNXRGh19D7CIpqaXGqxlPvQi4i7URkqYjsFpFdIvKIP4IFmtRWRUS6nyK06u+43G7+syodt+fqPGZVqabkRFEFC/Y5IPg3xJkkhsaPY9Sg6VbHalT+aJG7gJ8ZY3oCw4CHRKSnH9YbMEpLjvPsovupcBSRb8situoN0k+Wski7WJRqUMYYXl91iGq3B5ctlphW/4/7p/7R6liNrt6F3BiTZYzZ7LtfDOwBmtWl58MjWjEiaRh2EUKD7PQu30Vy5X4+2ZqpVxVSqgF9uSebtBPeiyfbbMJ3R3fC4bg6T/q5GL/2kYtICjAAWHeeefeLyEYR2ZiTk+PPl20Spo79A6mRHXg0uBUjTTjXF71HaFUe/1l1CI92sSjld/O//B3LVs2peXxjnySSW4RZF8hCfivkIhIBfAj82BhTdPZ8Y8zLxphUY0xqQkKCv162ybAHBTNz0kt0Ck+iXWwYoaacyYXvcji7kK/2X31fXEpZad/++Xx4aD6ZnldJLnuJdtFBTOmbZHUsy/ilkIuIA28Rf8sY85E/1hmQQmNg1E8IDQmmZaSTxOpMxhTP56PNmZRUuqxOp9RVwVNVxhtr/+LtF8eQZ8vl3pGdCbI334Pw/HHUigCvAXuMMX+pf6QAl9ANBnyTxKgQJEjIZhn24kV8tFkvD6eUP3i2vMW1J20kuIMIxkH/rr+gY2Kk1bEs5Y+vsJHAPcA1IrLVd5vsh/UGrm43kN2mD+/FFbMlpIJiM5dVe/dx6GSp1cmUCmzHd3By8zxiq2zcXRxFh6Dp3DZiiNWpLOePo1ZWGmPEGNPXGNPfd1vgj3ABS4TI1PswISE47EIlVcRXfMjb6w5jjO74VOqKVJdTvvIlsou9p+AfCenByJF3E+l0WBzMes23U6mBhUe04q7+PyDG4aCLZwg5zns5mFPKylrXDlRK1Z178385fuwoHgMVtlC+bj+DsV0TrY7VJDS/Ay4bUe+e0/lDywEsOuzk8HbvELcfbMpgQHIsESG66ZWqq7375vLm7v8yvCqENjhYHjmV20b1wWa7+gfEqgttkTew8BadubFvEnHh3sF7SipcfLwl0+JUSgWO8rI8/m/j8xx1VTE7sogvwluR2Hs8nRIirI7WZGghbwQhQXZmDGkHgDEe1u7eyJFcHVRLqbo4eGQZeZVleDwGBw4yo+7k1tR2VsdqUrSQN5KBybH0jK8gqvKPlFc/y9tfrdQdn0rVQcu2N+Kw/ZIWJplomcS0IQOI0h2cZ9BC3liMobr0OfJsGVTj4tiJ51mdpmd8KnUp72/MoJTWFDsfI6rVbYzTHZzn0ELeSMRmY3rqw4TY7QC0qi5g68o5VLn0akJKXciBnBI2pufVPP7msGTdwXkeWsgbUadO1zI95VruKo1mclkEA08uZNmOQ1bHUqrJqaooojzvIO9tOFozLTUljs7N/AzOC9FC3siuG/Nr+rdIBiDUU8rJNW9SXFFtcSqlmpbP1/yJ33xyD1XpLxHkqcBuE24d2KxGx74sWsgbm8NJwtj7CHF4N33P4jUsWbPe4lBKNR0nc/bwxdGl5LiqSLOvIbp6Kdd0TyQxyml1tCZLC7kFgtoPJ6bDIAAMHrJ2vsDxAj0cUSmAvG3/R5DLg8djiDIxlIZPZkq/1lbHatK0kFtBhFbX/IDCMBvvRBaxKjiNtz//m9WplLJe1jY6HU/j7twoBleGYrffztT+bfVM6EvQQm4RiW7D0U69ybJ7xynfnT+PnYd1x6dqxtwu2DSLE8UV2DyQYEbijB3KNd31cMNL0UJuoenX/JrYoDDsCG3dySzYkqEnCanma/8iqvIyOFlcSbUEszriOm4d2JbgIC1Tl6JbyEIhzmhmDv4pbW3f42jYz9hX4GTj4XyrYynV6MrLcine/i7HiyrwGFgXfg2JLVsxpEOc1dECghZyiw3s+w369j99HY4PN2XgcutJQqp5WbzuL/y6LI157gKy7TFsCxvO7ant8F6ATF2KFvIm4Ma+SYT5dubkFFeydJ+euq+aj6LCoyzN+Ioil4s1znIWRvWkb3ILurXSk3/qSgt5ExAecvoK4GLKWbL6WYpLiyxOpVTjKCrOJFzCcLkNkSaSwuAbuC21rdWxAooW8iZifLdEWrEYqXyMDPcy3vr8GasjKdUo2rQZSkj0syRwI8G2mxjdJYGk6FCrYwUULeRNRHCQjR4toUIqAdiQs5TsXL0Ahbr6bcso5FBuJYUhUyhzjmJafz0V/3JpIW9Cpk/4MVESQbixMbo0mPSv3rc6klINyhjDx5szah6P755YczUtVXdayJuQkOBQbu/xAN8pjKF/lRNH2hcU5WZZHUupBlF4bAvrD+aSkV8OQIjDxuQ+SRanCkxayJuYMSNvxxXRAQDxuNj/xesWJ1LK/zIy1vLrxQ+ycPFMEiu3AjCxR0uiQ/XKP1fCL4VcRF4XkWwR2emP9TVnYrPRYtR3ah4HHVlBfuZ+CxMp5X/zNr1IpctDGscpN/MIDbYzqXcrq2MFLH+1yGcBk/y0rmava98hFMX2BqAEN58s/n8WJ1LKf6pP7MJdmEmly4MguOy3ckPvJMKCdWCsK+WXQm6M+QrIu+SCqk5EhKSx32aNs5zXogtYUrGDDdvnWh1LKb9w7PyQ28ujmV4cSUd3d4Ii+zChhw6MVR+N1kcuIveLyEYR2ZiTo2cuXkqXbr3Jim5HNQYDvL/pJYxHT91XAS5nH+6snZwoqqCNK5ii4LuZ0rc1Tofd6mQBrdEKuTHmZWNMqjEmNSEhobFeNqDdOuoX2LER5wkhrGIgR3NLrI6kVP3smsPJkkpcHsPe0AHYo5MY203rQX3pUStNWL/OfRka/32qQp7maOjNfLL9hNWRlLpirtyDuDM2kV1cCQgbw8YwrX9rHHYtQ/WlW7CJmzL+Tqrt4QBsPVpA+slSixMpdWXeWvM0z1ZkcchWRVpId0JatGVEp3irY10V/HX44TvAGqCbiGSIyHf9sV4F7eLCGNT+9JjMn2w9ZmEapa7MyZw9rM/dzW5PBe9HFLEivB9T+7bGbtNhav3BX0et3GmMSTLGOIwxbY0xr/ljvcprWv/WnBqWeX/6BtZsX2RtIKUu09eHl1Ll9mCMIdYkEh6fylC9aITf6IGbAaBNTCgDW5bwdfqL5MkRPtgQy7De1yI27RlTgaFfn/uJ2NWSyKoP8diHM61fa2zaGvcbrQQB4rreyRTIUQyGbFceSze8bXUkpers893HKTLJFDp/QkTCOIakaGvcn7SQB4jObTvRNXwAAB2qg6na9iXohZpVACipdLF4d3bN46l9tTXub1rIA8j0sT/jzpI4bimNpFX+MY7uXmN1JKUuzhg+33Wcimo3AEkxTgZra9zvtJAHkC7tuhLRemLN4xOr3tJWuWqyqitLeX72NHZv+DNOj/fShdP6tdHWeAPQQh5guo6/C494T2cOyk/j6N71FidS6vzWbH2VHWUn2McKQiqfJik6hMEpsVbHuippIQ8wrVq1paztGAAMhq0rX7E4kVLnMm4Xyw/Mp8rlHR9IbAO4aUBbRLQ13hC0kAegruPvJt3hYnZEMe95tvLVpjlWR1LqDJKxnjsLgxleHkqUCSEi4TZS22trvKFoIQ9AiUnt2JnQhsygagDmb9Pzr1TTUrV7PuUl1QyvCKOvawpTB3bT1ngD0kIeoG4d+RMEwY4QVOFmf6YOqKWaiNwD5KbvwO0Bj9jJSxrLIG2NNygt5AGqR8cBDI+dQkt5iOOhTzJ/T6HVkZQCoHL3Z5wsqQJgf0hvJg7qrq3xBqaFPIDdfP0vyA3pBSLsyCjkkI6MqCxWXJTJZ3s+pdx3EZRjLcdq33gj0EIewFpFn3lyxafbdGREZa1lm17hI/J4OTqfpWERjBgyTFvjjUALeYCb0u/0yIhbj+Rx6IReOlVZw1VdwZfpSzHGUCmGguiBehZnI9FCHuDaxIQysK2TmMoPCa58lA+WPGt1JNVMlVe5cLqHEm7CcZpgJg6bqWdxNhIdxvYqkBK8hDUsBoH9hStJzykgJSHG6liqmVl+oIicoOkY+620Dj3OiM6trY7UbGiL/Cpw7ZDvERnkBMBNBUtWvGdxItXcVFS7+XyX9xBYERs3pI7Uq/80Ii3kVwFHSDg3JF/L2PIw7iuKoW36WjLzy6yOpZqRpXuzKa10ARAfEaJX/2lkWsivElNH/5hx9jicxkZidSarVq+wOpJqJvLzj7F28+nP2419kwiya2lpTLq1rxbOaGJ6Tah56Ni/gKzCcgsDqebivWV/40jFs7Qqe5IU2caITi2sjtTsaCG/isQPuoUop3f/dYfKfSxdv83iROpqV1ZRxuac1bgwHLGfoHNSqbbGLaBb/GoS3YbozsMoFw/rnGXsSPsn2UUVVqdSV7G1q+cS5fL2jYeJk2+Mvc/iRM2TXwq5iEwSkX0ikiYiv/THOtWV8fQex39iC1npLCPLtodPN2mrXDWMKpcH2bWUu4ujuas4mutaXU9oSJjVsZqlehdyEbED/wBuAHoCd4pIz/quV12Z+HYjaROeAIAbD/u+/i8nSyotTqWuRpu3bCS2LB2AtjiZOv4hawM1Y/5okQ8B0owxB40xVcC7wE1+WK+6AmKzMbnHLbSyhdLJM4KyoGks2JFldSx1lXG5PWRv/KTmcXCnUQRH6iGHVvFHIW8DHK31OMM37Qwicr+IbBSRjTk5OX54WXUhqX3u5TvXf8DR0Hsot8excv9J8kqrrI6lriJrdx+ibfEWAIJsQocRt1icqHlrtJ2dxpiXjTGpxpjUhISExnrZZkmCHHRvl0jnxAgA3B7DZzu1Va78w+X2sGjD83waVsCRoGpCk7oR3LKb1bGaNX8U8kygXa3HbX3TlIVEhKn9To918dXXORSUaatc1d/qtCyOV20izVHFh5HF5Pfsb3WkZs8fhXwD0EVEOohIMDADmOuH9ap66tU6ig7x4YS4jxBRNpuFO49bHUkFOI/HsHjDXCrEuwM91hFK/z53WpxK1Xv0Q2OMS0QeBhYBduB1Y8yueidT9WcMkRX/S4lrN8UY1u3szeS+dxHldFidTAWo9el5ZLpSibJHEeZZyDWduhPkcFodq9nzyzC2xpgFwAJ/rEv5j9hsRITYsNnA7QGpms+indcwPbXdpZ+s1FmMMczb7r0KVUVQV67tN44bBpxzXIOygJ7ZeZWb0GcmIUF2kl0ORpfmsn73foorqq2OpQLQxsP5ZBV4zxR2OuxM7NnS4kTqFC3kV7mUlLH8rtVo7q2MpYMriO5Fa/hi9wmrY6kAY4xhXq1rwl7TPZGIEL0uTVOhhbwZaNX7dlpGhQDQp2w9y3dl1IwdrVRdbDlaQEXWO7Qtn02UlHBdL22NNyVayJuDNoOITmyH02Ej2FTQqXg9i/doq1zVjTGGuVsOkccyDtqWIa7HKc1eb3UsVYsW8ubAZkO630jLKO/RBW0rlvHFzkzKqrRVri5tW0YhhSfmUyGViIAjJJgWSQOsjqVq0ULeXHQYy/HIED6KKubj8CM4yhaxeE+21alUE+dtjWcyujSNoRWhxNiDGN12NA6HjnLYlGghby4cTtISO3Hc6Qag0rOERTuOaatcXdT2jEJcx3fRseo4YyrDeCakPRMHPWh1LHUWLeTNyLhBDxIe5CBIhDhPKJ6qXL7UVrm6AGMMc7cdY1DpVwC0iAghrMsEnJFJFidTZ9Pjh5qRyKg23NvzXooqWvHfr1uBCJ/vPsHEHi0JDbZbHU81MTsziyjJSqN91X5sAomRTugx1epY6jy0Rd7MDBh0P6OGTyUx2rvjs6zSxZd79QgWdSZvazyT1pWfUoWhRXgIjg7DIUpb402RFvJmyG4TpvQ9PTLi57tOUFHttjCRamp2ZhaRmbWLTY6tvBpdwMbICkx3bY03VVrIm6lhHVuQEBkCxkVVeZb2lasap1rjTtcnGAxuBxyJjEXiO1sdTV2AFvLmylNNv8glOCp/iaPq7yzadVxb5QqAXceKOJhTikh7wgglJMjGdb3usTqWugjd2dlMFRSks+b4e5Tbqyn1lNKiZBVL9rZich/tA23OjDF86htTpSDkG4ztOpOBMVvp2nmyxcnUxWiLvJlqEd+VoQn9CLHbCDZCSsVqbZUrdmcVkZZdAvj2pfRrT++e0xGbloqmTP86zdh1gx7mJkcsD5XGMa4sl/DiQyzdq33lzdWp48ZPGd0lnrjwYAsTqbrSQt6MJST24sZOU0iODAVgaOlSPtuprfLmatexIg4cP0mLqr3YbaLdbAFEC3lz1+tm4sJDCA6y0b7ya8JLDuvIiM2QMYZPtmYSXbWAHPN3unv+iCd3ndWxVB1pIW/uottgaz+sZrzyQaWfs2jXCR2DpZnZnlHIwewCSswq3GJIk0y2HV1ldSxVR1rIFfS+lciwYLaEVbDIuRF7ySq9ilAzYoxhztZMOlWsJ85dTbDdRrg9mJEDv291NFVHevihgphkPolLYE3VYSqqPIS4P2HRzmFM6NFSL+fVDGw+UkDGyWLuLV1DlCcSW2QI5Z3GERoWZ3U0VUfaIlcAXDP4EULtQdhtAqaEoIp0Fu08bnUs1cBO9Y33Kt9IpLuAhAgnfcJbMiRVh6oNJFrIFeA9rvyGduOZkjgOE/wHSoPa8+XeExRVVFsdTTWgjYfzOZ5XxODSZdhteIdt6HkTOEKtjqYuQ70KuYhMF5FdIuIRkVR/hVLWmDT+KW6d9ifi41sBUFntYeEObZVfrTweb2u8W/lKwj3FxEeE4IhoAV2uszqaukz1bZHvBG4BvvJDFtUEiAjT+repebxkbzaFZdoqvxqtPZTLibxc9tjnMCeimIoIG/S6GYJCrI6mLlO9CrkxZo8xZp+/wqimYWByDMktvNdkdFcXM39HlsWJlL+5Pd4xVaKqPqSSKjJD3fzHXoK7w1iro6kr0Gh95CJyv4hsFJGNOTk5jfWy6gqICNd3geiK5zHVv2LFnn3klVZZHUv50eoDJ8kuqsRQiE2EYLuNSV1vwe5wWh1NXYFLFnIRWSwiO89zu+lyXsgY87IxJtUYk5qQkHDliVWDMx4PS7f/gnz7PiqpIqziXeZvP3bpJ6qA4HJ7akY4LHT+kCk9nmJsqyEM6fcdi5OpK3XJg4SNMRMbI4hqOsRm47pu0zm85Z+4Kl2EuveyaW8a1/dqRWKUttgC3bJ9OeSWeH9hRTiDmDpsIk7H9RanUvWhhx+q8xrY5x5GRCbzzapYbi0JZ0jxEj7akml1LFVPFdVu5tX6dTW5TxJOh154O9DV9/DDm0UkAxgOzBeRRf6JpawmNhv3jvg1oyKjEISe5Zs5/PV20k+WWh1N1cOiXcepLDuB011IbHgw47slWh1J+UF9j1r52BjT1hgTYoxpaYzR32dXk6S+hKcMITrUARjGFc/jw01HrU6lrlBRRTWLdh3HWfUatqrfMC7yC4JFhyy+GmjXirq4Qd8iKTYCARKrj1Jx8DN2HyuyOpW6AvO2ZRFUtomTcojiIBefZX/I0SMrrY6l/EALubq4yFY4+96MO8LGhxHFHLK9zwfrtmOMsTqZugw5xZUs23uCHuWLCTFCSJCd/jFdaNdhvNXRlB9oIVeX5Ok5jTkx1RxxVFNJFQUnXmbj4XyrY6nLMGdLJp3LtjK8vJCHK1owLjiabwz7pdWxlJ9oIVeXZHOEckvfbxNstyFApKeYjzYexuX2WB1N1cHRvDI2HchiZMnnAHSJDufOXt8iIbGnxcmUv2ghV3XSr9edTEoaSmf7PWSEPkZ2iYsVaSetjqXq4INNGQwsXUG4p4joUAfh0S2g5zesjqX8SAu5qhOx2bht8gukDr0dRAD4dOsxvVBzE7fveDH7j+ylZ/lyBGgV7YR+MyA4zOpoyo+0kKvLMqFHItFhDgAKy6v1Qs1NmDGGDzYdJbj6Df4bmcv+KBfBCR2hwziroyk/00KuLktIkJ2bfMPciqli2aY5evGJJmrT4Xyyjy0nVw5TYfOwJKyUw92vA5v+t7/a6F9UXbZRneNp51hPUOWvyKn6D+8tn2d1JHWWKpeH9zYeRagmzIQSbLcxKK4HHTvq0ElXI72yrrpsNgzBti8oFe/p+psP/Z307LGkJOrFepuKz3cf9w6M5RhORFgq17ZZzPDeM6yOpRqItsjVZRObje9e8wec9iCCjTCs3MOORW/oSUJNREFZFQtqXQzkG4M6M2XcE7SI72phKtWQtJCrK9KyZR/u7XYXM4ui6VvlpO2xz9m5a7vVsRTw4eZMKqu9x/i3iQ1lTFcd//9qp4VcXbHRo35Ii5a9ARA8FC/9G9XVeiUhKx06WcqeXe/TunIFGMMdg9tht4nVsVQD00KurpwI7W/8GdiDAQgrO8buz2dZm6kZM8bw7urN5PMxR3iHXvydrtF6RFFzoIVc1Ut4fDukn3cnWrl4WHDov+w5sMLiVM3ThvR8co79nSqqMWLIcRzDJfpfvDnQv7Kqt17j72BPVEtmRRWy21HB61/9Hld1hdWxmpUql4c1Kz5nSnE+bVwOgu02vjnoIULD9Eii5kALuaq3oKAgkkc9QKWvK/ZEVT4r175mbahmZvG2QwzK/og4j527y6L4Ufvr6dXjVqtjqUaihVz5xcg+I+geeQ0Rxk5Hz7WsLxmnhyM2kvzSKgrXvkGEuxCAxPgE+o76H4tTqcbUZE4Iqq6uJiMjg4oK/UnuL06nk7Zt2+JwOBrl9e694df86eMRHLUlwYky1h7MY3inFo3y2s3ZoqVL6FGyDoBQh52EcQ+AM8riVKoxNZlCnpGRQWRkJCkpKYjo4VL1ZYwhNzeXjIwMOnTo0Civ2To2gmG9+/PFbu9AWrM3HKFP22giQprMx+yqs+Hrfaw6+jRBjiA6VwcT13UYtpSRVsdSjazJdK1UVFTQokULLeJ+IiK0aNGi0X/hfGNAG2LDvYcjFle4eH9dGvv2z2/UDM1FeWU1s5c/SoGtnE/Ci9kcKyRc83DNMMOq+WgyhRzQIu5nVmxPp8PO3UOTAQh2Z7Bp9w95ftVTpB34vNGzXO0+Wr+eIk8uADYReg+bCXqUSrNUr0IuIs+KyF4R2S4iH4tIjJ9yqQA2IDmWAckxBFe/TqHkU1bt4vW1z1BanHXpJ6s6OZpXxtKDIYjjN8SZ1gxPGM6QvjooVnNV3xb5F0BvY0xf4GvgsfpHso7dbqd///41t2eeecZv6966dSsLFizw2/qauruGtofQ+wjGgfHAwFIbYetfBY9e57O+PB7Df9ekY4zBZYsjKfkZvjflWatjKQvVay+UMab27+W1wG31i2Ot0NBQtm7d2iDr3rp1Kxs3bmTy5MkNsv6mJi48mKmDh7Jg5XQmFM2jncdOZcY2nLs+gj4B/TGx3LKvszmY4x1C2G4TZo7sSJAjxOJUykr+PJzgO8DsC80UkfuB+wGSk5MvuqLvztrgx1hnem3m4MtavrCwkCFDhjB37ly6devGnXfeyTXXXMN9993HD37wAzZs2EB5eTm33XYbv/vd7wDYsGEDjzzyCKWlpYSEhPDFF1/wxBNPUF5ezsqVK3nssce44447GuLtNSnXdE9kzcFJZFVV0KZ0ORkF5XTa8T7SohO0HmB1vIC0Yt0/Wb4TsKcCcGPfJO91OFWzdslCLiKLgVbnmfW4MeYT3zKPAy7grQutxxjzMvAyQGpqapM8U6S8vJz+/fvXPD5VcF988UVmzpzJI488Qn5+Pvfddx8ATz/9NHFxcbjdbiZMmMD27dvp3r07d9xxB7Nnz2bw4MEUFRURFhbG73//ezZu3MiLL75o0btrfDab8K3hKfzh5ASSqo/QpuIQ+aVVxK74C/ljfkpckhbzy3H06Cre2DELj9tDSuVOqlp9j8l9kqyOpZqASxZyY8xFrw0lIjOBKcAEE+Cn8l2oa+Xaa6/l/fff56GHHmLbtm0109977z1efvllXC4XWVlZ7N69GxEhKSmJwYO9Lf+oqOZ9YkZyizCu7dWahdtv5/b8f3OkoICPQgo5uORn/Oz6f+nFDurIlOby2tLfUul2A3DctpeHB7fGYW9SB54pi9Sra0VEJgGPAmONMWX+iXT53R8NzePxsGfPHsLCwsjPz6dt27YcOnSI5557jg0bNhAbG8vMmTP1rNQLmNa/NRvS8/jE3Eto5f+SWVVBaLCdfy5+hJ9O/S9h4Xrhg4uqKqN6yR+ZcFLIDbVTYoP+HR+lZ7uWVidTTUR9v85fBCKBL0Rkq4j8yw+Zmpy//vWv9OjRg7fffptvf/vbVFdXU1RURHh4ONHR0Zw4cYLPPvsMgG7dupGVlcWGDd5+/uLiYlwuF5GRkRQXF1v5NizjdNi5d3gK+UGJFAffjtsN1W4PXUMTcNp1J91FuV2YlX8l89BeIqttzCiOoXXIvdw1doLVyVQTUt+jVjr7K0hTcHYf+aRJk/j2t7/Nq6++yvr164mMjGTMmDE89dRT/O53v2PAgAF0796ddu3aMXKk97To4OBgZs+ezQ9/+EPKy8sJDQ1l8eLFjB8/nmeeeYb+/fs3m52dtfVpG824bgks2zeU+Ko84irTGDvmRWw6JsiFGQMbXyPvwAYKy70XiFgTeTN3TJyhwx6oM4gV3dqpqalm48aNZ0zbs2cPPXr0aPQsV7umtF0rqt38ft5uThR6u6A6JUbwi0nd9VJkF7Bm9bN02r+aE9lluD2wPnw8oal3cs+w9lZHUxYRkU3GmNSzp+ueEtVonA47943uiM1XuA9klzDfd7V34/Hoafy1bNj6Om+mfcRTlcc4Li72OfuT3noyt6e2tTqaaoK0kKtG1SE+nJv6t655PHfrMQ7mlLBwxe/526rf8tnyJzHN/OzP4qJM3tnxOlUuD/nGzcLwUJbE3ML9YzoREmS3Op5qgrSQq0Y3uXcSnRMjAO9wu7MWPM+89EUAzD+8iA2r/9fbP9xMRUa1YVr3H+GqFiJMJMUhj3DTwGRS4sOtjqaaKC3kqtHZbML3RnfE6fC2LrPcI4klEYBu4mTA4S2waVazLeYV1W4WHe1OhO0BxPEwHZPaManX+c7JU8pLC7myREJkSM1wtx5bOMc9P2NoaE++b4vHIQJfL4R1/242g2wZ38WqjTG8ve4I2UWVlDl6IaEd+N7oDjX7FZQ6Hy3kyjLDO7UgNcU7fraRUNZVfp/yxFongx1cCmteALfLooSNY+2mf/PXD26msuAoy/blsCrtZM28u4cmEx+hx9qri9NCfgFPPvkkzz33XJ2WXbZsGVOmTKm5v3r16oaMdtUQEe4Z3p4WEd4rCpW7hGcKr6Oy3eiaZXYe+pJ/zb2H0pLjVsVsUMvX/oU3d83iYHUBz396Hx+v3lIzb3inFgzvqNc8VZemhdzPtJBfnoiQIH54TRdCHN6PYnZJNS+UTsTT+Vr2mQpe9ZxkZ3E6//vpNzlxbJPFaf3IGNj5EaQtBsBjDEfKqqnCO5ZKSnw49w7X69equmm6p4dtfx92flC3ZTtNgKH3nzlt3ctw4MvTj3vfBn2nX3Q1Tz/9NG+88QaJiYm0a9eOQYMGMXjwYJ599lnGjRvHY489hs1m4+mnn2bhwoX8+Mc/JiwsjFGjRgGQnp7Ov/71L+x2O2+++SYvvPACo0ePvuhrKmgXF8Z3R3XkpaVpAOw5Xsy7MdcS1+YoriPeY8uDPR5iwhKtjOk/lSWw7p+QsZGxtkjKjIfPqwxljp/hssUSHerg4fGdCQ7Sdpaqm6ZbyBvZpk2bePfdd9m6dSsul4uBAwcyaNAgZs2axW233cYLL7zAwoULWbduHRUVFdx3330sWbKEzp0715xun5KSwgMPPEBERAQ///nPLX5HgWVQ+1huGtCGT7ZkAvDl3my+NeJh7k/oyXtb/sl9w35FSEw7i1PWn8nZj6z+G5R6+8ENhviq7pTYbsFjC8VuEx66pnPNBayVqgv9yvdZsWIFN998M2FhYURFRTFt2jQAevXqxT333MOUKVN4/fXXCQ4OZu/evXTo0IEuXbogInzzm9+0OP3VYWrfJAalxNY8fnPtYULjJ/PkbZ/QstO5oylXVQbOIGTG42Hpmud4cdEDuEtyaqZvDR3GK7Y78NhCAfjWiBQ6JURYFVMFqKbbIu87/ZJdIRc19P5zu1uu0I4dO4iJiSE7O9sv61PnJyJ8Z2QHsosqOZpXhttj+MfSNH4zpSdn7/I7eGgJ/1z1JBOSJzJh+M9xOMIsyVwXxuPhtfnfYWv+PgAW2IKYGtyaPe3v4sXdMeDrBr+uV0tGdo63LqgKWNoi9xkzZgxz5syhvLyc4uJiPv30UwA++ugj8vLy+Oqrr/jhD39IQUEB3bt3Jz09nQMHDgDwzjvv1KynOQ9X6w9Oh52Hr+lMpNPbxiiucPHXxV/XjP4H3lPYX1vzNOWeaualf8aCOd+CzM1WRb4ksdloG92h5vGeECe7+/+S5/fF1Uzr1Saa2wYFfteRsoYWcp+BAwdyxx130K9fP2644YaaK/z88pe/5NVXX6Vr1648/PDDPPLIIzidTl5++WVuvPFGBg4cSGLi6Z1wU6dO5eOPP6Z///6sWLHCqrcT0OIjQnhwfOeak2CyCip4dtFeiiq8xby4JIuIIG9XRCg2rqkysPx/YfmfoLhpHqZ43cjH6RaZzNhWw5g09GX+vraEarf3ZKeW0U4eGNtRR4FUV0yHsb3KBfJ2XX8oj5e/OlBzpn5SjJNHJ3UnyunA7api1aZ/4Di0kuGeWj2EtiCKu0zA1WEssXGdGj1z9omdzF//Z24e8ANi2g45Y56ruoKvc6r4+5f7a4p4bHgwj17fjcQovYCyujQdxlYFnCEd4rhvdEdOHUqdVVDBnxZ6W+b2oGDGDP0Jw7/xOnQcf/pJHhfL9szmiXn38Mrcezl8aGnjhC04ypIlj/PUou+zKX8v89b/9ZyxYvaf1CKuGoYWctWkDe3Y4pxi/uzCfTXdLDijYdgDcN3TENcJlzGs8pRiMGwr2E/+ie0NF640F3Z/AgsehQU/p03WTjx4i/S6knTyMjfULLonq4jnF58u4jFhWsSV/zTdo1aU8hnqO039lRUHMQaOFZTz7MJ9/M+kbkQ5Hd6F4jvD9U9TfOBLWm//N1+XZBAtDvr0ufuMdVVXljL3qyfokNiPTu3HEB2TcllZjh3byMGMNezOXMV3ywz2Wt3a3cRJLwmlIiyWmwf9iDhf18r5ivgvJmkRV/6jhVwFhPMV82c+28tD4zvTJsa74xMRYjtP5EedJ3I8awt5OTuxh595ON+RjNUszfLeEra/wm+j+kGLTuAIg6AQDrlK2VeZS4gjjD7tryG+9cAznv/xuj+zpzgdgH32BHrie227A9oM4tvtRxDSZjBi8/7YXXMglzdWp2sRVw1KC7kKGEM7tsAAr/qK+YnCCp6at5t7h6cwvNOZR5q3ShpAq6QB56zjwLF1Nfc7EQKlOd7bqfmeIuZ5CgCQ8jzGnVXIW0Yk1RTyDZ4yerYZAimjoO0QCA7jVHmucnmYveEIy/adXndMWDCPahFXDUALuQoowzq2wG4TXl95iCqXhyqXh1dXHCQtu5g7BidfcnySbsljud5VzoG8fXStPHd43CpO76A8UZx5zvyOif3JK8+hc3wfBvW8Hc7TNXOypJKXlh7gcG5pzbSW0U4emdCFllrEVQPQQn4BTz755GWNmTJ37lx2797NL3/5y8t+rTlz5tC1a1d69uwJwBNPPMGYMWOYOPHc09IVDE6JIynayUvLDnCi0HtBhmX7cjh0sowHx3e66Pjd7duPpn1730BmbhfkH4LiLHBVgauCTkXpXFuaQZWrkgRn3DnPH9jvXgb2u/eC6992tIBXVx6irNaXRGpKHN8emVJzRSSl/K1ehVxE/gDcBHiAbGCmMeaYP4IFEpfLxbRp02rGZ7lcc+bMYcqUKTWF/Pe//70/412V2saG8cSUnvxnVTob0/MAOJxbyu8+3c13RqYwIDn2EmsA7EEQ38V78+nmu12uareHuVuPsWBH1unV24TbU9sxoUeiDkerGlR9Dz981hjT1xjTH5gHPFH/SF7zD87n4S8f5uEvH2b+wfnnzP9o/0c18788/OU589/e83bN/JWZK+v0mk8//TRdu3Zl1KhR7NvnHRfjwIEDTJo0iUGDBjF69Gj27t0LwMyZM3nggQcYOnQojz76KLNmzeLhhx+msLCQ9u3b4/Fdoqy0tJR27dpRXV3NK6+8wuDBg+nXrx+33norZWVlrF69mrlz5/I///M/9O/fnwMHDjBz5kw++OADFi5cyPTpp8ebqX0Bi88//5zhw4czcOBApk+fTklJyeVt4KuA02HngbEduWtocs1ZkWWVLl5cksazi/aSlt3wQyW4PYYV+3N4/OMdZxTx2PBgfnFDdyb2bKlFXDW4ehVyY0xRrYfhQMBeLbf2MLYLFixgwwbvMcD3338/L7zwAps2beK5557jwQcfrHlORkYGq1ev5i9/+UvNtOjoaPr378/y5csBmDdvHtdffz0Oh4NbbrmFDRs2sG3bNnr06MFrr73GiBEjmDZtGs8++yxbt26lU6fTZyNOnDiRdevWUVrq7WudPXs2M2bM4OTJkzz11FMsXryYzZs3k5qaekaG5kREmNCjJb+4ofsZQ7/uzSrmjwv28rfFX5/RV+0vxhjWHczl13N2MmtVOrklVTXzerWJ5rdTe+oohqrR1LuPXESeBu4FCoHxF1nufuB+gOTk5Pq+rN/VHsYWYNq0aVRUVLB69eozWsWVlZU196dPn47dfm6/5x133MHs2bMZP3487777bk3x37lzJ7/+9a8pKCigpKSE66+//qKZgoKCmDRpEp9++im33XYb8+fP509/+hPLly9n9+7djBw5EoCqqiqGDx9e720QyDolRPDbqT35aHMmK/af5NTQEzsyCtmRUcjA9rFM69eatrGh9Wohuz2GbRkFzNmSSWZ++RnzIpxBTOnbmonalaIa2SULuYgsBlqdZ9bjxphPjDGPA4+LyGPAw8Bvz7ceY8zLwMvgHWvlUq97Y8cbubHjjRecf0uXW7ilyy0XnH9Xj7u4q8ddl3qZi/J4PMTExLB169bzzg8PDz/v9GnTpvGrX/2KvLw8Nm3axDXXXAN4u2PmzJlDv379mDVrFsuWLbtkhhkzZvDiiy8SFxdHamoqkZGRGGO49tprzxh1UUGk08G3RqRwQ+9WzN12jLUHc2vOkt98OJ/Nh/NpERFMj6Qo761VFNFhjouu0xhDZkE5e7KK2ZNVxL4TxVRUuc9YJjTYzqTerZjYo6Xu0FSWuGQhN8bU9dCJt4AFXKCQN3Vjxoxh5syZPPbYY7hcLj799FO+//3v06FDB95//32mT5+OMYbt27fTr1+/i64rIiKCwYMH88gjjzBlypSaVntxcTFJSUlUV1fz1ltv0aZNG+DiQ9+OHTuW73znO7zyyivMmDEDgGHDhvHQQw+RlpZG586dKS0tJTMzk65du/pxiwSuxCgn3xvdkRv6JDFnSyabD+fXzMstqWLl/pOs3O+9Qk9SjJNOCREE2c/tZSytdLHveDFFtYbQrS3EYWNij5Zc36sV4SF6AJiyTn2PWulijNnve3gTsLf+kaxRexjbxMTEmmFs33rrLX7wgx/w1FNPUV1dzYwZMy5ZyMHbvTJ9+vQzWt1/+MMfGDp0KAkJCQwdOrSmeM+YMYP77ruPv//973zwwZnXKbXb7UyZMoVZs2bxxhtvAJCQkMCsWbO48847a7p6nnrqKS3kZ2kTE8pD4zuTfrKU+Tuy2HWskMpqzxnLZBVUkFVQcVnrjQkLZmiHOCb1aXV6iAClLFSvYWxF5EO8R2t5gMPAA8aYc8+iOIsOY9t4dLue5nJ7SM8tZbevm+RAdgluz6U//+EhQXRrFUlPX5dMy6gQ7QNXlrjQMLb1apEbY26tz/OVakxBdhudEyPpnBjJtH6tqXS52X+ihJziSsx5DriyidAhPpzkuDAt3KpJ04491WyFBNnp3Sba6hhK1VuTGo/ciqsVXc10eyrVPDSZQu50OsnNzdXi4yfGGHJzc3E6dZAmpa52TaZrpW3btmRkZJCTk3PphVWdOJ1O2rZta3UMpVQDazKF3OFw0KFDB6tjKKVUwGkyXStKKaWujBZypZQKcFrIlVIqwNXrzM4rflGRHLxngl6JeOCkH+P4i+a6PJrr8miuy9NUc0H9srU3xiScPdGSQl4fIrLxfKeoWk1zXR7NdXk01+VpqrmgYbJp14pSSgU4LeRKKRXgArGQv2x1gAvQXJdHc10ezXV5mmouaIBsAddHrpRS6kyB2CJXSilVixZypZQKcE2qkIvIJBHZJyJpIvLL88wPEZHZvvnrRCSl1rzHfNP3icjFL0/v/1w/FZHdIrJdRL4Ukfa15rlFZKvvNreRc80UkZxar/+9WvO+JSL7fbdvNXKuv9bK9LWIFNSa1yDbS0ReF5FsEdl5gfkiIn/3Zd4uIgNrzWvIbXWpXHf78uwQkdUi0q/WvHTf9K0isvF8z2/AXONEpLDW3+qJWvMu+vdv4Fz/UyvTTt/nKc43ryG3VzsRWeqrA7tE5JHzLNNwnzFjTJO4AXbgANARCAa2AT3PWuZB4F+++zOA2b77PX3LhwAdfOuxN2Ku8UCY7/4PTuXyPS6xcHvNBF48z3PjgIO+f2N992MbK9dZy/8QeL0RttcYYCCw8wLzJwOfAQIMA9Y19LaqY64Rp14PuOFULt/jdCDeou01DphX37+/v3OdtexUYEkjba8kYKDvfiTw9Xn+PzbYZ6wptciHAGnGmIPGmCrgXbwXdK7tJuAN3/0PgAkiIr7p7xpjKo0xh4A03/oaJZcxZqkxpsz3cC3QGGPH1mV7Xcj1wBfGmDxjTD7wBTDJolx3Au/46bUvyBjzFZB3kUVuAv5rvNYCMSKSRMNuq0vmMsas9r0uNN5nqy7b60Lq87n0d65G+WwBGGOyjDGbffeLgT1Am7MWa7DPWFMq5G2Ao7UeZ3DuhqhZxhjjAgqBFnV8bkPmqu27eL91T3GKyEYRWSsi3/BTpsvJdavvZ9wHItLuMp/bkLnwdUF1AJbUmtxQ2+tSLpS7IbfV5Tr7s2WAz0Vkk4jcb0Ge4SKyTUQ+E5FevmlNYnuJSBjeYvhhrcmNsr3E2+U7AFh31qwG+4w1mfHIrwYi8k0gFRhba3J7Y0ymiHQElojIDmPMgUaK9CnwjjGmUkS+j/fXzDWN9Np1MQP4wBjjrjXNyu3VZInIeLyFfFStyaN82yoR+EJE9vparI1hM96/VYmITAbmAF0a6bXrYiqwyhhTu/Xe4NtLRCLwfnn82BhT5M91X0xTapFnAu1qPW7rm3beZUQkCIgGcuv43IbMhYhMBB4HphljKk9NN8Zk+v49CCzD+03dKLmMMbm1srwKDKrrcxsyVy0zOOunbwNur0u5UO6G3FZ1IiJ98f79bjLG5J6aXmtbZQMf47/uxEsyxhQZY0p89xcADhGJpwlsL5+LfbYaZHuJiANvEX/LGPPReRZpuM9YQ3T8X+HOgiC8nfwdOL2TpNdZyzzEmTs73/Pd78WZOzsP4r+dnXXJNQDvDp4uZ02PBUJ89+OB/fhpx08dcyXVun8zsNac3rlyyJcv1nc/rrFy+ZbrjnfnkzTG9vKtM4UL77y7kTN3RK1v6G1Vx1zJePf5jDhrejgQWev+amBSI+Zqdepvh7cgHvFtuzr9/Rsql29+NN5+9PDG2l6+9/5f4G8XWabBPmN+27h+2hiT8e7tPQA87pv2e7ytXAAn8L7vg70e6FjruY/7nrcPuKGRcy0GTgBbfbe5vukjgB2+D/MO4LuNnOuPwC7f6y8Futd67nd82zEN+HZj5vI9fhJ45qznNdj2wts6ywKq8fZBfhd4AHjAN1+Af/gy7wBSG2lbXSrXq0B+rc/WRt/0jr7ttM33N368kXM9XOuztZZaXzTn+/s3Vi7fMjPxHvxQ+3kNvb1G4e2D317rbzW5sT5jeoq+UkoFuKbUR66UUuoKaCFXSqkAp4VcKaUCnBZypZQKcFrIlVIqwGkhV8pHRGJE5EGrcyh1ubSQK3VaDN4RNpUKKFrIlTrtGaCTb7zqZ60Oo1Rd6QlBSvn4Rq2bZ4zpbXUWpS6HtsiVUirAaSFXSqkAp4VcqdOK8V6mS6mAooVcKR/jHet7le+ivbqzUwUM3dmplFIBTlvkSikV4LSQK6VUgNNCrpRSAU4LuVJKBTgt5EopFeC0kCulVIDTQq6UUgHu/wMIlAGkmXesSgAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "kws = dict(kind='spline', s=0.5, periodic=True)\n",
+    "x_dot_dxdt = dxdt(x, t, **kws)\n",
+    "x_dot_derivative = pk.differentiation.Derivative(**kws)(x, t)\n",
+    "\n",
+    "plot_kws = dict(alpha=0.7, linewidth=3)\n",
+    "plt.plot(t, x_dot, label='Exact', **plot_kws)\n",
+    "plt.plot(t, x_dot_dxdt, '--', label='dxdt', **plot_kws)\n",
+    "plt.plot(t, x_dot_derivative, ':', label='derivative', **plot_kws)\n",
+    "plt.xlabel('t')\n",
+    "plt.title('Equivalence of methods')\n",
+    "plt.legend();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Custom differentiation method\n",
+    "\n",
+    "We also have the option of defining a fully custom differentiation function. Here we'll wrap numpy's `gradient` method. We can pass this method into  the `differentiator` argument of a `KoopmanContinuous` object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-10-20T00:26:19.526100Z",
+     "start_time": "2020-10-20T00:26:19.515760Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from numpy import gradient\n",
+    "\n",
+    "def diff(x, t):\n",
+    "    return gradient(x, axis=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-10-20T00:26:20.349165Z",
+     "start_time": "2020-10-20T00:26:20.336317Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/brian/Documents/Dropbox (uwamath)/Brian/Research/PyKoopman/pykoopman/pykoopman/regression/_dmd.py:37: UserWarning: pydmd regressors do not require the y argument when fitting.\n",
+      "  warn(\"pydmd regressors do not require the y argument when fitting.\")\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "KoopmanContinuous(differentiator=<function diff at 0x7f7e668f4510>,\n",
+       "                  observables=Identity(),\n",
+       "                  regressor=<pydmd.dmd.DMD object at 0x7f7e64777c88>)"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model = pk.KoopmanContinuous(differentiator=diff)\n",
+    "model.fit(x, t=t)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/pykoopman/__init__.py
+++ b/pykoopman/__init__.py
@@ -1,8 +1,18 @@
+from pkg_resources import DistributionNotFound
+from pkg_resources import get_distribution
+
+try:
+    __version__ = get_distribution(__name__).version
+except DistributionNotFound:
+    pass
+
 from .koopman import Koopman
+from .koopman_continuous import KoopmanContinuous
 
 
 __all__ = [
     "Koopman",
+    "KoopmanContinuous",
     "common",
     "differentiation",
     "observables",

--- a/pykoopman/common/__init__.py
+++ b/pykoopman/common/__init__.py
@@ -1,7 +1,9 @@
 from .validation import check_array
+from .validation import drop_nan_rows
 from .validation import validate_input
 
 __all__ = [
     "check_array",
+    "drop_nan_rows",
     "validate_input",
 ]

--- a/pykoopman/common/validation.py
+++ b/pykoopman/common/validation.py
@@ -1,15 +1,33 @@
 import numpy as np
 from sklearn.utils import check_array as skl_check_array
 
-DT_DEFAULT = object()
+T_DEFAULT = object()
 
 
-def validate_input(x, dt=DT_DEFAULT):
+def validate_input(x, t=T_DEFAULT):
     if not isinstance(x, np.ndarray):
         raise ValueError("x must be array-like")
     elif x.ndim == 1:
         x = x.reshape(-1, 1)
-    return check_array(x)
+    x = check_array(x)
+
+    if t is not T_DEFAULT:
+        if t is None:
+            raise ValueError("t must be a scalar or array-like.")
+        # Apply this check if t is a scalar
+        elif np.ndim(t) == 0 and (isinstance(t, int) or isinstance(t, float)):
+            if t <= 0:
+                raise ValueError("t must be positive")
+        # Only apply these tests if t is array-like
+        elif isinstance(t, np.ndarray):
+            if not len(t) == x.shape[0]:
+                raise ValueError("Length of t should match x.shape[0].")
+            if not np.all(t[:-1] < t[1:]):
+                raise ValueError("Values in t should be in strictly increasing order.")
+        else:
+            raise ValueError("t must be a scalar or array-like.")
+
+    return x
 
 
 def check_array(x, **kwargs):
@@ -19,3 +37,28 @@ def check_array(x, **kwargs):
         )
     else:
         return skl_check_array(x, **kwargs)
+
+
+def drop_nan_rows(arr, *args):
+    """
+    Remove rows in all inputs for which `arr` has `_np.nan` entries.
+
+    Parameters
+    ----------
+    arr : numpy.ndarray
+        Array whose rows are checked for nan entries.
+        Any rows containing nans are removed from ``arr`` and all arguments
+        passed via ``args``.
+    *args : variable length argument list of numpy.ndarray
+        Additional arrays from which to remove rows.
+        Each argument should have the same number of rows as ``arr``.
+
+    Returns
+    -------
+    arrays : tuple of numpy.ndarray
+        Arrays with nan rows dropped.
+        The first entry corresponds to ``arr`` and all following entries
+        to ``*args``.
+    """
+    nan_inds = np.isnan(arr).any(axis=1)
+    return (arr[~nan_inds], *[arg[~nan_inds] for arg in args])

--- a/pykoopman/differentiation/__init__.py
+++ b/pykoopman/differentiation/__init__.py
@@ -1,3 +1,4 @@
+from ._derivative import Derivative
 from ._finite_difference import FiniteDifference
 
-__all__ = ["FiniteDifference"]
+__all__ = ["Derivative", "FiniteDifference"]

--- a/pykoopman/differentiation/_derivative.py
+++ b/pykoopman/differentiation/_derivative.py
@@ -1,0 +1,91 @@
+"""
+Wrapper classes for differentiation methods from the :doc:`derivative:index` package.
+
+Some default values used here may differ from those used in :doc:`derivative:index`.
+"""
+from derivative import dxdt
+from numpy import arange
+from sklearn.base import BaseEstimator
+
+from ..common import validate_input
+
+
+class Derivative(BaseEstimator):
+    """
+    Wrapper class for differentiation classes from the :doc:`derivative:index` package.
+    This class is meant to provide all the same functionality as the
+    `dxdt <https://derivative.readthedocs.io/en/latest/api.html\
+        #derivative.differentiation.dxdt>`_ method.
+
+    This class includes a :meth:`__call__` method.
+
+    Parameters
+    ----------
+    derivative_kws: dictionary, optional
+        Keyword arguments to be passed to the
+        `dxdt <https://derivative.readthedocs.io/en/latest/api.html\
+        #derivative.differentiation.dxdt>`_
+        method.
+
+    Notes
+    -----
+    See the `derivative documentation <https://derivative.readthedocs.io/en/latest/>`_
+    for acceptable keywords.
+    """
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def set_params(self, **params):
+        """
+        Set the parameters of this estimator.
+        Modification of the pysindy method to allow unknown kwargs. This allows using
+        the full range of derivative parameters that are not defined as member variables
+        in sklearn grid search.
+
+        Returns
+        -------
+        self
+        """
+        if not params:
+            # Simple optimization to gain speed (inspect is slow)
+            return self
+        else:
+            self.kwargs.update(params)
+
+        return self
+
+    def get_params(self, deep=True):
+        """Get parameters."""
+        params = super().get_params(deep)
+
+        if isinstance(self.kwargs, dict):
+            params.update(self.kwargs)
+
+        return params
+
+    def __call__(self, x, t):
+        """
+        Perform numerical differentiation by calling the ``dxdt`` method.
+
+        Paramters
+        ---------
+        x: np.ndarray, shape (n_samples, n_features)
+            Data to be differentiated. Rows should correspond to different
+            points in time and columns to different features.
+
+        t: np.ndarray, shape (n_samples, )
+            Time points for each sample (row) in ``x``.
+
+        Returns
+        -------
+        x_dot: np.ndarray, shape (n_samples, n_features)
+        """
+        x = validate_input(x, t=t)
+
+        if isinstance(t, (int, float)):
+            if t < 0:
+                raise ValueError("t must be a positive constant or an array")
+            t = arange(x.shape[0]) * t
+
+        return dxdt(x, t, axis=0, **self.kwargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+derivative
 scikit-learn>=0.23
 numpy
 scipy

--- a/test/differentiation/test_differentiation.py
+++ b/test/differentiation/test_differentiation.py
@@ -1,0 +1,93 @@
+"""Tests for differentiation methods."""
+import numpy as np
+import pytest
+from derivative import dxdt
+
+from pykoopman.differentiation import Derivative
+
+
+@pytest.fixture
+def data_1D_quadratic():
+    t = np.linspace(0, 5, 100)
+    x = t.reshape(-1, 1) ** 2
+    x_dot = 2 * t.reshape(-1, 1)
+
+    return x, t, x_dot
+
+
+@pytest.fixture
+def data_1D_bad_shape():
+    t = np.linspace(0, 5, 100)
+    x = t ** 2
+    x_dot = 2 * t
+
+    return x, t, x_dot
+
+
+@pytest.fixture
+def data_2D_quadratic():
+    t = np.linspace(0, 5, 100)
+    x = np.zeros((len(t), 2))
+    x[:, 0] = t ** 2
+    x[:, 1] = -(t ** 2)
+
+    x_dot = np.zeros_like(x)
+    x_dot[:, 0] = 2 * t
+    x_dot[:, 1] = -2 * t
+
+    return x, t, x_dot
+
+
+@pytest.fixture(params=["data_1D_quadratic", "data_1D_bad_shape", "data_2D_quadratic"])
+def data(request):
+    return request.getfixturevalue(request.param)
+
+
+@pytest.mark.parametrize(
+    "kws",
+    [
+        dict(kind="spectral"),
+        dict(kind="spline", s=1e-2),
+        dict(kind="trend_filtered", order=0, alpha=1e-2),
+        dict(kind="finite_difference", k=1),
+        dict(kind="savitzky_golay", order=3, left=1, right=1),
+    ],
+)
+def test_derivative_package_equivalence(data, kws):
+    x, t, _ = data
+
+    x_dot_pykoopman = Derivative(**kws)(x, t)
+    x_dot_derivative = dxdt(x, t, axis=0, **kws).reshape(x_dot_pykoopman.shape)
+
+    np.testing.assert_array_equal(x_dot_pykoopman, x_dot_derivative)
+
+
+def test_bad_t_values(data_1D_quadratic):
+    x, t, _ = data_1D_quadratic
+
+    method = Derivative(kind="finite_difference", k=1)
+
+    with pytest.raises(ValueError):
+        method(x, t=-1)
+
+    with pytest.raises(ValueError):
+        method(x, t[:5])
+
+    with pytest.raises(ValueError):
+        inds = np.arange(len(t))
+        # Swap two time entries
+        inds[[0, 1]] = inds[[1, 0]]
+        method(x, t[inds])
+
+
+def test_accuracy(data):
+    x, t, x_dot = data
+
+    method = Derivative(kind="finite_difference", k=1)
+    x_dot_method = method(x, t)
+
+    if x_dot.ndim == 1:
+        x_dot = x_dot.reshape(-1, 1)
+
+    # Ignore endpoints
+    np.testing.assert_allclose(x_dot[1:-1], x_dot_method[1:-1])

--- a/test/test_koopman_continuous.py
+++ b/test/test_koopman_continuous.py
@@ -1,0 +1,19 @@
+import pytest
+from sklearn.utils.validation import check_is_fitted
+
+from pykoopman import KoopmanContinuous
+from pykoopman.differentiation import Derivative
+
+
+@pytest.mark.parametrize(
+    "data",
+    [pytest.lazy_fixture("data_random"), pytest.lazy_fixture("data_random_complex")],
+)
+def test_derivative_integration(data):
+    x = data
+
+    diff = Derivative(kind="finite_difference", k=1)
+    model = KoopmanContinuous(differentiator=diff)
+
+    model.fit(x)
+    check_is_fitted(model)


### PR DESCRIPTION
This PR implements, `pykoopman.differentiation.Derivative` a wrapper class for the `dxdt` method of the [derivative](https://derivative.readthedocs.io/en/latest/) package—this solution is very similar to what is done in PySINDy. Included are some basic tests and a notebook demonstrating how to pass differentiation objects into the `KoopmanContinuous` class.

The way things are implemented here, the user can either choose a method provided by the derivative package, passing the keyword arguments into our `Derivative` constructor:

```python
diff = pykoopman.differentiation.Derivative(kind="finite_difference", k=1)
method = pykoopman.KoopmanContinuous(differentiator=diff)
```

or they can define their own differentiation method and pass it in instead:

```python
def custom_method(x, t):
    return np.gradient(x, axis=0)

method = pykoopman.KoopmanContinuous(differentiator=custom_method)
```