### PR TITLE
Fix FutureWarning by setting `rcond=None` in `np.linalg.lstsq` calls

### DIFF
--- a/src/pykoopman/analytics/_ms_pd21.py
+++ b/src/pykoopman/analytics/_ms_pd21.py
@@ -137,7 +137,8 @@ class ModesSelectionPAD21(BaseAnalyzer):
                     :, self.small_to_large_error_eigen_index[:k]
                 ]
                 sparse_measurement_matrix = np.linalg.lstsq(
-                    eigenfunction_evaluated_on_traj_top_k, validate_data
+                    eigenfunction_evaluated_on_traj_top_k, validate_data,
+		    rcond=None
                 )[0]
                 residual = (
                     eigenfunction_evaluated_on_traj_top_k @ sparse_measurement_matrix
@@ -301,7 +302,7 @@ class ModesSelectionPAD21(BaseAnalyzer):
             bool_non_zero = np.linalg.norm(coefs_enet_comp[:, :, i_alpha], axis=0) > 0
             phi_tilde_scaled_reduced = phi_tilde_scaled[:, bool_non_zero]
             coef_enet_comp_reduced_i_alpha = np.linalg.lstsq(
-                phi_tilde_scaled_reduced, X
+                phi_tilde_scaled_reduced, X, rcond=None
             )[0]
             coefs_enet_comp[
                 :, bool_non_zero, i_alpha

--- a/src/pykoopman/analytics/_pruned_koopman.py
+++ b/src/pykoopman/analytics/_pruned_koopman.py
@@ -66,7 +66,7 @@ class PrunedKoopman:
 
         # pruned V
         selected_eigenphi = self.psi(x.T).T
-        result = np.linalg.lstsq(selected_eigenphi, x)
+        result = np.linalg.lstsq(selected_eigenphi, x, rcond=None)
         # print('refit residual = {}'.format(result[1]))
         self.W_ = result[0].T
 

--- a/src/pykoopman/observables/_base.py
+++ b/src/pykoopman/observables/_base.py
@@ -250,7 +250,7 @@ class ConcatObservables(BaseObservables):
             ].measurement_matrix_
         else:
             g = self.transform(X)
-            tmp = np.linalg.lstsq(g, X)[0].T
+            tmp = np.linalg.lstsq(g, X, rcond=None)[0].T
             assert tmp.shape == self.measurement_matrix_.shape
             self.measurement_matrix_ = tmp
 

--- a/src/pykoopman/observables/_radial_basis_functions.py
+++ b/src/pykoopman/observables/_radial_basis_functions.py
@@ -158,7 +158,7 @@ class RadialBasisFunction(BaseObservables):
 
         xlift = self._rbf_lifting(x)
         # self.measurement_matrix_ = x.T @ np.linalg.pinv(xlift.T)
-        self.measurement_matrix_ = np.linalg.lstsq(xlift, x)[0].T
+        self.measurement_matrix_ = np.linalg.lstsq(xlift, x, rcond=None)[0].T
 
         return self
 

--- a/src/pykoopman/observables/_random_fourier_features.py
+++ b/src/pykoopman/observables/_random_fourier_features.py
@@ -102,7 +102,7 @@ class RandomFourierFeatures(BaseObservables):
             # z[:,:x.shape[1]] = x
             # z[:,x.shape[1]:] = self._rff_lifting(x)
             z = self._rff_lifting(x)
-            self.measurement_matrix_ = np.linalg.lstsq(z, x)[0].T
+            self.measurement_matrix_ = np.linalg.lstsq(z, x, rcond=None)[0].T
 
         return self
 

--- a/src/pykoopman/regression/_edmd.py
+++ b/src/pykoopman/regression/_edmd.py
@@ -80,7 +80,7 @@ class EDMD(BaseRegressor):
 
         # X1, X2 are row-wise data, so there is a transpose in the end.
         self._coef_ = U.conj().T @ X2T @ V @ np.diag(np.reciprocal(s))
-        # self._coef_ = np.linalg.lstsq(X1, X2)[0].T  # [0:Nlift, 0:Nlift]
+        # self._coef_ = np.linalg.lstsq(X1, X2, rcond=None)[0].T  # [0:Nlift, 0:Nlift]
         self._state_matrix_ = self._coef_
         [self._eigenvalues_, self._eigenvectors_] = scipy.linalg.eig(self.state_matrix_)
         # self._ur = np.eye(self.n_input_features_)


### PR DESCRIPTION
Added `rcond=None` to all `np.linalg.lstsq` usages to eliminate the FutureWarning about upcoming changes to the default `rcond` parameter. This update ensures compatibility with future NumPy versions and prevents deprecated behavior warnings.