### PR TITLE
bugfix in metric score - parenthese was at wrong position

### DIFF
--- a/src/pykoopman/koopman.py
+++ b/src/pykoopman/koopman.py
@@ -554,9 +554,9 @@ class Koopman(BaseEstimator):
                 )
         else:
             if cast_as_real:
-                return metric(y.real, self.predict(x).real, **metric_kws)
+                return metric(y.real, self.predict(x, **metric_kws).real)
             else:
-                return metric(y, self.predict(x), **metric_kws)
+                return metric(y, self.predict(x, **metric_kws))
 
     def _observable(self):
         """Returns the observable transformation."""


### PR DESCRIPTION
I found a parenthese that was the wrong position, which prevented model.score() to behave as expected when using control inputs.